### PR TITLE
fix: docker stack rm opencrvs

### DIFF
--- a/v1.7.0/setup/3.-installation/3.3-set-up-a-server-hosted-environment/4.3.7-backup-and-restore/4.3.7.1-restoring-a-backup.md
+++ b/v1.7.0/setup/3.-installation/3.3-set-up-a-server-hosted-environment/4.3.7-backup-and-restore/4.3.7.1-restoring-a-backup.md
@@ -49,7 +49,7 @@ cd / && bash /opt/opencrvs/infrastructure/backups/download.sh --passphrase=$BACK
 9. OpenCRVS requires to be re-deployed to function properly once a backup has been restored.  Run this command to **take OpenCRVS down / OFFLINE**.
 
 ```
-docker stack opencrvs down
+docker stack rm opencrvs
 ```
 
 10. Run this command to clear your terminal session of the history of any exported secrets (security step)


### PR DESCRIPTION
Reference link: https://docs.docker.com/reference/cli/docker/stack/rm/

Correct way to stop docker stack is `docker stack rm <stack name>`