### PR TITLE
doc: Explicitly mention provision user and group IDs must be 1000

### DIFF
--- a/developer-manual/README.md
+++ b/developer-manual/README.md
@@ -57,16 +57,21 @@ We want to ensure there partition mounted to / has enough disk space. Like we se
 
 If you only see a smaller disk mounted to /,  check what you see in `lsblk -o NAME,FSTYPE,SIZE,MOUNTPOINT,LABEL`. If you just found another another disk there, refer to Cameroon project's ansible playbook.
 
-#### Create a user named `provision`
+### Create a user named `provision`
 
-The next commands will create a user named **provision**,  make it a sudoer (needed for provisioning) and finally generate an SSH key **for logging in as the user.** The SSH private key will not persist on the server as it should only be stored in Github Secrets.
+{% embed url="https://youtu.be/tVvhj_vsGLE" %}
 
-```
-adduser --gecos "OpenCRVS Provisioning user" --disabled-password provision
+The next commands will create a user named **provision**, make it a sudoer (needed for provisioning), and finally generate an SSH key **for logging in as the user**. The SSH private key will not persist on the server as it should only be stored in Github Secrets.
+
+It is important to note that the provision user and group IDs should be set to 1000. These IDs are the default for OpenCRVS and are used internally by the OpenCRVS application. They should be reserved to ensure that there are no conflicts with other users or groups on the system.
+
+<pre><code>
+<strong>addgroup --gid 1000 provision</strong>
+<strong>adduser --gecos "OpenCRVS Provisioning user" --disabled-password --uid 1000 --gid 1000 provision</strong>
 usermod -aG sudo provision
 echo 'provision ALL=(ALL) NOPASSWD:ALL' | sudo tee -a /etc/sudoers
-su provision
-```
+su - provision
+</code></pre>
 
 #### Create SSH keys for accessing `provision`
 

--- a/v1.6.0/setup/3.-installation/3.3-set-up-a-server-hosted-environment/3.3.1-provision-your-server-nodes-with-ssh-access.md
+++ b/v1.6.0/setup/3.-installation/3.3-set-up-a-server-hosted-environment/3.3.1-provision-your-server-nodes-with-ssh-access.md
@@ -57,14 +57,16 @@ eu.ui-avatars.com
 
 {% embed url="https://youtu.be/tVvhj_vsGLE" %}
 
-The next commands will create a user named **provision**,  make it a sudoer (needed for provisioning) and finally generate an SSH key **for logging in as the user.** The SSH private key will not persist on the server as it should only be stored in Github Secrets.
+The next commands will create a user named **provision**, make it a sudoer (needed for provisioning), and finally generate an SSH key **for logging in as the user**. The SSH private key will not persist on the server as it should only be stored in Github Secrets.
 
-<pre><code><strong>
-</strong><strong>adduser --gecos "OpenCRVS Provisioning user" --disabled-password provision
-</strong>usermod -aG sudo provision
+It is important to note that the provision user and group IDs should be set to 1000. These IDs are the default for OpenCRVS and are used internally by the OpenCRVS application. They should be reserved to ensure that there are no conflicts with other users or groups on the system.
+
+<pre><code>
+<strong>addgroup --gid 1000 provision</strong>
+<strong>adduser --gecos "OpenCRVS Provisioning user" --disabled-password --uid 1000 --gid 1000 provision</strong>
+usermod -aG sudo provision
 echo 'provision ALL=(ALL) NOPASSWD:ALL' | sudo tee -a /etc/sudoers
-su provision
-cd ~
+su - provision
 </code></pre>
 
 

--- a/v1.7.0/setup/3.-installation/3.3-set-up-a-server-hosted-environment/3.3.1-provision-your-server-nodes-with-ssh-access.md
+++ b/v1.7.0/setup/3.-installation/3.3-set-up-a-server-hosted-environment/3.3.1-provision-your-server-nodes-with-ssh-access.md
@@ -57,16 +57,17 @@ eu.ui-avatars.com
 
 {% embed url="https://youtu.be/tVvhj_vsGLE" %}
 
-The next commands will create a user named **provision**,  make it a sudoer (needed for provisioning) and finally generate an SSH key **for logging in as the user.** The SSH private key will not persist on the server as it should only be stored in Github Secrets.
+The next commands will create a user named **provision**, make it a sudoer (needed for provisioning), and finally generate an SSH key **for logging in as the user**. The SSH private key will not persist on the server as it should only be stored in Github Secrets.
 
-<pre><code><strong>
-</strong><strong>adduser --gecos "OpenCRVS Provisioning user" --disabled-password provision
-</strong>usermod -aG sudo provision
+It is important to note that the provision user and group IDs should be set to 1000. These IDs are the default for OpenCRVS and are used internally by the OpenCRVS application. They should be reserved to ensure that there are no conflicts with other users or groups on the system.
+
+<pre><code>
+<strong>addgroup --gid 1000 provision</strong>
+<strong>adduser --gecos "OpenCRVS Provisioning user" --disabled-password --uid 1000 --gid 1000 provision</strong>
+usermod -aG sudo provision
 echo 'provision ALL=(ALL) NOPASSWD:ALL' | sudo tee -a /etc/sudoers
-su provision
-cd ~
+su - provision
 </code></pre>
-
 
 
 ### Create SSH keys for each environment for `provision`

--- a/v1.8.0/setup/3.-installation/3.3-set-up-a-server-hosted-environment/3.3.1-provision-your-server-nodes-with-ssh-access.md
+++ b/v1.8.0/setup/3.-installation/3.3-set-up-a-server-hosted-environment/3.3.1-provision-your-server-nodes-with-ssh-access.md
@@ -57,16 +57,17 @@ eu.ui-avatars.com
 
 {% embed url="https://youtu.be/tVvhj_vsGLE" %}
 
-The next commands will create a user named **provision**,  make it a sudoer (needed for provisioning) and finally generate an SSH key **for logging in as the user.** The SSH private key will not persist on the server as it should only be stored in Github Secrets.
+The next commands will create a user named **provision**, make it a sudoer (needed for provisioning), and finally generate an SSH key **for logging in as the user**. The SSH private key will not persist on the server as it should only be stored in Github Secrets.
 
-<pre><code><strong>
-</strong><strong>adduser --gecos "OpenCRVS Provisioning user" --disabled-password provision
-</strong>usermod -aG sudo provision
+It is important to note that the provision user and group IDs should be set to 1000. These IDs are the default for OpenCRVS and are used internally by the OpenCRVS application. They should be reserved to ensure that there are no conflicts with other users or groups on the system.
+
+<pre><code>
+<strong>addgroup --gid 1000 provision</strong>
+<strong>adduser --gecos "OpenCRVS Provisioning user" --disabled-password --uid 1000 --gid 1000 provision</strong>
+usermod -aG sudo provision
 echo 'provision ALL=(ALL) NOPASSWD:ALL' | sudo tee -a /etc/sudoers
-su provision
-cd ~
+su - provision
 </code></pre>
-
 
 
 ### Create SSH keys for each environment for `provision`


### PR DESCRIPTION
By default OpenCRVS needs user and group IDs set to 1000.
IDs are widely used by provision and deployment scripts.

Example:
- https://github.com/opencrvs/opencrvs-countryconfig/blob/develop/infrastructure/server-setup/tasks/data-partition.yml#L56-L57

Goal of this change to documentation is to give end users explicit notice about user and group IDs used by OpenCRVS