### PR TITLE
Documentation: Releasing guide(ocrvs-9564)

### DIFF
--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -4,7 +4,6 @@ OpenCRVS follows a structured and coordinated release process to ensure stabilit
 
 ## Create the release pull request
 
-
 The first step in launching a new release is to create the release pull request—arguably the simplest part of the process. To do so, execute the GitHub Action titled `Release - Start a new release` available in the [opencrvs-core](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) repository.
 
 To trigger this action, you are required to provide only the release version.
@@ -12,3 +11,25 @@ To trigger this action, you are required to provide only the release version.
 {% hint style="warning" %}
 Ensure that the version number adheres to [semantic versioning](https://semver.org/) (e.g., `1.6.1`).
 {% endhint %}
+
+## Deployment to a Release Environment
+
+You can deploy a draft release to a dedicated release environment, which is highly beneficial for validation and testing purposes. The process is streamlined and straightforward.
+
+To initiate the deployment, simply run the [`Create Hetzner Server`](https://github.com/opencrvs/opencrvs-farajaland/actions/workflows/create-hetzner-server.yml) GitHub Action. This workflow automates the server provisioning process and requires only two input parameters:
+
+- **`env_name`**: A short identifier for the environment (preferably 3–5 characters).  
+  *Tip:* Use the release version as a reference, such as `v17` for version `1.7.0`.
+
+- **`env_type`**: Specify the environment configuration.  
+  Use `multi-node` for production deployments and `single-node` for all other cases.
+
+Once triggered, the action will handle the rest of the setup automatically.
+
+## Comprehensive guide till completion the release
+
+TODO
+
+## Verification steps during release
+
+TODO

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -12,8 +12,8 @@ To trigger this action, you are required to provide only the release version.
 
 {% hint style="warning" %}
 **⚠️ Caution** 
-Ensure that the version number adheres to [semantic versioning](https://semver.org/) (e.g., `1.6.1`).
-For a hotfix release, ensure that the branch corresponding to the previous release exists in both the `core` and `countryconfig` repositories.
+- Ensure that the version number adheres to [semantic versioning](https://semver.org/) (e.g., `1.6.1`).
+- For a hotfix release, ensure that the branch corresponding to the previous release exists in both the `core` and `countryconfig` repositories.
 {% endhint %}
 
 Once triggered, the action performs the following steps automatically:

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -25,30 +25,18 @@ Once triggered, the action performs the following steps automatically:
 
 ### Deployment to a Release Environment
 
-You can deploy a draft release to a dedicated release environment. The process is streamlined and easy to follow.
+You can deploy a draft release to a dedicated release environment by running the `Release - Provision Environment` workflow.
+This workflow requires two input parameters:
+- **`Environment`**: A short identifier for the environment.  
+  *Tip:* If you are creating a release for version `v1.9.0`, enter `v19` as the input. This will result in a deployment like `v19.opencrvs.dev`.
+- **`Core image tag`**: The Docker image tag for, core that you want to deploy.
 
-- To initiate the deployment, run the [`Create Hetzner Server`](https://github.com/opencrvs/opencrvs-farajaland/actions/workflows/create-hetzner-server.yml) GitHub Action.  
-  This workflow will:
-  - Create a new server on Hetzner Cloud
-  - Register DNS records via Cloudflare
+Once triggered, this workflow will:
+- Create a server for the release environment
+- Provision the environment
+- Deploy the release environment
 
-  It requires two input parameters:
-  - **`Short server name`**: A short identifier for the environment (typically 3–5 characters).  
-    *Tip:* Use the release version for clarity, e.g., `v17` for version `1.7.0`.
-  - **`Environment type`**: Defines the server configuration.  
-    Use `multi-node` for production environments and `single-node` for all others.
-
-- To provision the newly created server, use the [`Provision Environment`](https://github.com/opencrvs/opencrvs-farajaland/actions/workflows/provision.yml) workflow.  
-  This action requires two inputs:
-  - **Environment**: Select the environment you wish to provision.
-  - **Ansible tag**:  
-    *Tip:* Choose `all` if you are provisioning for the first time or want to perform a full setup. Otherwise, select the specific tag you want to update—this can significantly reduce provisioning time.
-
-- Once provisioning is complete, deploy the release using the appropriate workflow:
-  - For **production** and **staging** environments, use the [`Deploy to Prod/Staging`](https://github.com/opencrvs/opencrvs-farajaland/actions/workflows/deploy-prod.yml) workflow.
-  - For **other environments**, use the [`Deploy`](https://github.com/opencrvs/opencrvs-farajaland/actions/workflows/deploy.yml) workflow.
-
-- After deployment, seed the environment with necessary data using the [`Seed Data`](https://github.com/opencrvs/opencrvs-farajaland/actions/workflows/seed-data.yml) workflow.
+This provides a fully functional environment for validating and reviewing the release.
 
 ## Publishing the Release
 

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -35,7 +35,7 @@ This workflow requires two input parameters:
 
 {% hint style="warning" %}
 ⚠️ **Caution**  
-Make sure to run the workflow from the appropriate release branch.
+Make sure to run the workflow from the release branch.
 {% endhint %}
 
 Once triggered, this workflow will:

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -18,7 +18,6 @@ Once triggered, the action performs the following steps automatically:
 - **Opens a pull request** to begin the release process.
 - **Updates `CHANGELOG.md`** heading with the specified version number.
 - **Modifies all `package.json` files** across the repository to reflect the new version.
-- **Creates a draft GitHub release** associated with the specified version.
 
 ## Deployment to a Release Environment
 
@@ -36,30 +35,40 @@ Once triggered, the action will handle the rest of the setup automatically.
 
 ## Comprehensive Guide to Completing the Release
 
-Once the release pull request and draft release have been generated via the [`Release - Start a new release`](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) workflow, a few final tasks remain to fully complete the release process.
+Once the release pull request has been generated via the [`Release - Start a new release`](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) workflow, a few final tasks remain to fully complete the release process.
 
-### 1. Verify Docker Images
 
-- Confirm that the Docker images have been published to [Docker Hub](https://hub.docker.com/r/opencrvs/ocrvs-countryconfig/tags?name=v).
+### 1. Tag the Release
+
+Create a Git tag from the `HEAD` of the release branch. For example, to tag version `1.7.0`, run:
+
+```bash
+git tag v1.7.0
+git push origin tag v1.7.0
+```
+
+### 2. Verify Docker Images
+
+- Confirm that the Docker images have been published to [Docker Hub](https://hub.docker.com/r/opencrvs/ocrvs-countryconfig/tags?name=v). For post v1.7.0 check Github Container regestry.
 - Compare the size of the new images with those from the previous release.
 - If there is a significant difference in size, report it to the maintainers for investigation.
 
-### 2. Finalize GitHub Release
+### 3. Finalize GitHub Release
 
 - Copy the content from `CHANGELOG.md` into the GitHub Release notes.
 - Paste any changed "Copy" items into the release notes. You can generate these with [this tool](https://gist.github.com/rikukissa/9415b88016c0acfc0e0d4e00add45993).
 - Once finalized, **publish** the GitHub release.
 
-### 3. Publish NPM Release
+### 4. Publish NPM Release
 
 - In the core repository, ensure that the corresponding NPM package is published to reflect the new version.
 
-### 4. Version Control Management
+### 5. Version Control Management
 
 - In both the `core` and `countryconfig` repositories, **merge the release branch into `master`**.  
   ⚠️ **Do not squash merge** — use a regular merge to preserve history.
 
-### 5. Documentation Management
+### 6. Documentation Management
 
 - Add the new release notes to the official documentation.
 - Create a placeholder for the next version's documentation.
@@ -67,13 +76,13 @@ Once the release pull request and draft release have been generated via the [`Re
 - Publish the updated documentation.
 - Merge any open pull requests in the documentation repository, if appropriate.
 
-### 6. Environment Management
+### 7. Environment Management
 
 - Merge the latest `countryconfig` updates into your country-specific repository.
 - **For minor releases**: Deploy the new version to **production**.
 - **For hotfix releases**: Deploy the new version to **staging**.
 
-### 7. Team Communication
+### 8. Team Communication
 
 - Announce the newly published version to your team and stakeholders, ensuring they are informed and aligned.
 
@@ -81,6 +90,24 @@ Once the release pull request and draft release have been generated via the [`Re
 
 By following this structured checklist, you ensure a smooth, transparent, and high-quality release process.
 
-## Verification steps during release
+## Verification Steps During a Release
 
-TODO
+During the release process, it is critical to exercise extra caution and perform thorough validation at each stage to ensure accuracy and completeness. Below are essential verification tasks you must carry out:
+
+- **Check for pending pull requests**  
+  Ensure there are no open pull requests that need to be included in the release—this applies to both the `countryconfig` and `core` repositories.
+
+- **Verify Git tags**  
+  Before creating a new Git tag, confirm that a tag with the same version number does not already exist in either the `countryconfig` or `core` repositories.
+
+- **Validate Docker image availability**  
+  Check Docker Hub (or the GitHub Container Registry for versions post `1.7.0`) to confirm that Docker images have been built and published using the correct release version name.
+
+- **Confirm GitHub release publication**  
+  After publishing the GitHub release, open the repository’s **Releases** tab and verify that the release is publicly available and correctly labeled.
+
+- **Verify NPM package publication (core only)**  
+  For the `core` repository, ensure the NPM release has been published successfully. You can confirm this by checking for the presence of the corresponding version under the [@opencrvs/toolkit](https://www.npmjs.com/package/@opencrvs/toolkit?activeTab=versions) package on NPM.
+
+> ✅ Conducting these checks diligently helps avoid release inconsistencies and ensures a smooth experience for downstream users.
+

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -2,14 +2,18 @@
 
 OpenCRVS follows a structured and coordinated release process to ensure stability and alignment between the core platform and country-specific configurations. Releases are versioned semantically (e.g., v1.4.0). Each release is accompanied by migration notes, upgrade instructions, and full changelogs to support system integrators and implementers.
 
-## Create the release pull request
+## Initializing a Release
 
-The first step in launching a new release is to create the release pull request—arguably the simplest part of the process. To do so, execute the GitHub Action titled [`Release - Start a new release`](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) available in the [opencrvs-core](https://github.com/opencrvs/opencrvs-core) repository.
+### Create the release pull request
+
+The first step in launching a new release is to create the release pull request. To do so, execute the GitHub Action titled [`Release - Start a new release`](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) available in the [opencrvs-core](https://github.com/opencrvs/opencrvs-core) repository.
 
 To trigger this action, you are required to provide only the release version.
 
 {% hint style="warning" %}
-Ensure that the version number adheres to [semantic versioning](https://semver.org/) (e.g., `1.6.1`).
+ **⚠️ Caution** 
+- Ensure that the version number adheres to [semantic versioning](https://semver.org/) (e.g., `1.6.1`).
+- Ensure there are no open pull requests that need to be included in the release—this applies to both the `countryconfig` and `core` repositories.
 {% endhint %}
 
 Once triggered, the action performs the following steps automatically:
@@ -19,7 +23,7 @@ Once triggered, the action performs the following steps automatically:
 - **Updates `CHANGELOG.md`** heading with the specified version number.
 - **Modifies all `package.json` files** across the repository to reflect the new version.
 
-## Deployment to a Release Environment
+### Deployment to a Release Environment
 
 You can deploy a draft release to a dedicated release environment, which is highly beneficial for validation and testing purposes. The process is streamlined and straightforward.
 
@@ -33,7 +37,7 @@ To initiate the deployment, simply run the [`Create Hetzner Server`](https://git
 
 Once triggered, the action will handle the rest of the setup automatically.
 
-## Comprehensive Guide to Completing the Release
+## Publishing the Release
 
 Once the release pull request has been generated via the [`Release - Start a new release`](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) workflow, a few final tasks remain to fully complete the release process.
 
@@ -46,12 +50,26 @@ Create a Git tag from the `HEAD` of the release branch. For example, to tag vers
 git tag v1.7.0
 git push origin tag v1.7.0
 ```
+{% hint style="warning" %}
+ **⚠️ Caution** 
+- Before creating a new Git tag, confirm that a tag with the same version number does not already exist in either the `countryconfig` or `core` repositories.
+{% endhint %}
 
-### 2. Verify Docker Images
+### 2. Publish & Verify Docker Images
 
-- Confirm that the Docker images have been published to [Docker Hub](https://hub.docker.com/r/opencrvs/ocrvs-countryconfig/tags?name=v). For post v1.7.0 check Github Container regestry.
+- 🛠️ Publish Docker images for:
+  - **Core** using [this workflow](https://github.com/opencrvs/opencrvs-core/blob/develop/.github/workflows/build-images-from-branch.yml)
+  - **CountryConfig** using [this workflow](https://github.com/opencrvs/opencrvs-countryconfig/blob/develop/.github/workflows/publish-to-dockerhub.yml)
+- ✅ Verify that the Docker images have been published to the appropriate registry:
+  - **CountryConfig** and **Core** (pre `v1.7.0`): [Docker Hub](https://hub.docker.com/r/opencrvs/ocrvs-countryconfig/tags?name=v)
+  - **Core** (`v1.7.0` and later): [GitHub Container Registry (GHCR)](https://github.com/orgs/opencrvs/packages?repo_name=opencrvs-core)
 - Compare the size of the new images with those from the previous release.
 - If there is a significant difference in size, report it to the maintainers for investigation.
+
+{% hint style="warning" %}
+ **⚠️ Caution** 
+- Check Docker Hub (or the GitHub Container Registry for versions post `1.7.0` in core) to confirm that Docker images have been built and published using the correct release version name.
+{% endhint %}
 
 ### 3. Finalize GitHub Release
 
@@ -86,22 +104,7 @@ git push origin tag v1.7.0
 
 - Announce the newly published version to your team and stakeholders, ensuring they are informed and aligned.
 
----
-
-By following this structured checklist, you ensure a smooth, transparent, and high-quality release process.
-
-## Verification Steps During a Release
-
-During the release process, it is critical to exercise extra caution and perform thorough validation at each stage to ensure accuracy and completeness. Below are essential verification tasks you must carry out:
-
-- **Check for pending pull requests**  
-  Ensure there are no open pull requests that need to be included in the release—this applies to both the `countryconfig` and `core` repositories.
-
-- **Verify Git tags**  
-  Before creating a new Git tag, confirm that a tag with the same version number does not already exist in either the `countryconfig` or `core` repositories.
-
-- **Validate Docker image availability**  
-  Check Docker Hub (or the GitHub Container Registry for versions post `1.7.0`) to confirm that Docker images have been built and published using the correct release version name.
+### 9. Post Verification Steps 
 
 - **Confirm GitHub release publication**  
   After publishing the GitHub release, open the repository’s **Releases** tab and verify that the release is publicly available and correctly labeled.
@@ -109,5 +112,9 @@ During the release process, it is critical to exercise extra caution and perform
 - **Verify NPM package publication (core only)**  
   For the `core` repository, ensure the NPM release has been published successfully. You can confirm this by checking for the presence of the corresponding version under the [@opencrvs/toolkit](https://www.npmjs.com/package/@opencrvs/toolkit?activeTab=versions) package on NPM.
 
-> ✅ Conducting these checks diligently helps avoid release inconsistencies and ensures a smooth experience for downstream users.
+---
+
+By following this structured checklist, you ensure a smooth, transparent, and high-quality release process.
+
+
 

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -13,6 +13,7 @@ To trigger this action, you are required to provide only the release version.
 {% hint style="warning" %}
 **⚠️ Caution** 
 Ensure that the version number adheres to [semantic versioning](https://semver.org/) (e.g., `1.6.1`).
+For a hotfix release, ensure that the branch corresponding to the previous release exists in both the `core` and `countryconfig` repositories.
 {% endhint %}
 
 Once triggered, the action performs the following steps automatically:
@@ -51,7 +52,7 @@ You can deploy a draft release to a dedicated release environment. The process i
 
 ## Publishing the Release
 
-Once the release pull request has been generated via the [`Release - Start a new release`](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) workflow, a few final tasks remain to fully complete the release process.
+Once the release pull request has been generated via the [`Release - Start a new release`](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) workflow, a significant number of final tasks still remain to fully complete the release process.
 During this phase, it's common for issues to be discovered or additional pull requests to be merged into the release branch. Proceed carefully and ensure all necessary changes are included.
 
 {% hint style="warning" %}

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -33,9 +33,9 @@ You can deploy a draft release to a dedicated release environment. The process i
   - Register DNS records via Cloudflare
 
   It requires two input parameters:
-  - **`env_name`**: A short identifier for the environment (typically 3–5 characters).  
+  - **`Short server name`**: A short identifier for the environment (typically 3–5 characters).  
     *Tip:* Use the release version for clarity, e.g., `v17` for version `1.7.0`.
-  - **`env_type`**: Defines the server configuration.  
+  - **`Environment type`**: Defines the server configuration.  
     Use `multi-node` for production environments and `single-node` for all others.
 
 - To provision the newly created server, use the [`Provision Environment`](https://github.com/opencrvs/opencrvs-farajaland/actions/workflows/provision.yml) workflow.  
@@ -107,6 +107,7 @@ Check Docker Hub (or the GitHub Container Registry for versions post `1.7.0` in 
 
 - In both the `core` and `countryconfig` repositories, **merge the release branch into `master`**.  
   ⚠️ **Do not squash merge** — use a regular merge to preserve history.
+-  Also **merge the release branch back into the `develop` branch** after the release is finalized to keep `develop` up to date with the latest changes.
 
 ### 7. Documentation Management
 

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -12,6 +12,13 @@ To trigger this action, you are required to provide only the release version.
 Ensure that the version number adheres to [semantic versioning](https://semver.org/) (e.g., `1.6.1`).
 {% endhint %}
 
+Once triggered, the action performs the following steps automatically:
+
+- **Creates a release branch** following the naming convention: `release/{version_number}` (e.g., `release/1.6.1`).
+- **Opens a pull request** to begin the release process.
+- **Updates `CHANGELOG.md`** heading with the specified version number.
+- **Modifies all `package.json` files** across the repository to reflect the new version.
+
 ## Deployment to a Release Environment
 
 You can deploy a draft release to a dedicated release environment, which is highly beneficial for validation and testing purposes. The process is streamlined and straightforward.

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -4,7 +4,7 @@ OpenCRVS follows a structured and coordinated release process to ensure stabilit
 
 ## Create the release pull request
 
-The first step in launching a new release is to create the release pull request—arguably the simplest part of the process. To do so, execute the GitHub Action titled `Release - Start a new release` available in the [opencrvs-core](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) repository.
+The first step in launching a new release is to create the release pull request—arguably the simplest part of the process. To do so, execute the GitHub Action titled [`Release - Start a new release`](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) available in the [opencrvs-core](https://github.com/opencrvs/opencrvs-core) repository.
 
 To trigger this action, you are required to provide only the release version.
 
@@ -18,6 +18,7 @@ Once triggered, the action performs the following steps automatically:
 - **Opens a pull request** to begin the release process.
 - **Updates `CHANGELOG.md`** heading with the specified version number.
 - **Modifies all `package.json` files** across the repository to reflect the new version.
+- **Creates a draft GitHub release** associated with the specified version.
 
 ## Deployment to a Release Environment
 
@@ -33,9 +34,52 @@ To initiate the deployment, simply run the [`Create Hetzner Server`](https://git
 
 Once triggered, the action will handle the rest of the setup automatically.
 
-## Comprehensive guide till completion the release
+## Comprehensive Guide to Completing the Release
 
-TODO
+Once the release pull request and draft release have been generated via the [`Release - Start a new release`](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) workflow, a few final tasks remain to fully complete the release process.
+
+### 1. Verify Docker Images
+
+- Confirm that the Docker images have been published to [Docker Hub](https://hub.docker.com/r/opencrvs/ocrvs-countryconfig/tags?name=v).
+- Compare the size of the new images with those from the previous release.
+- If there is a significant difference in size, report it to the maintainers for investigation.
+
+### 2. Finalize GitHub Release
+
+- Copy the content from `CHANGELOG.md` into the GitHub Release notes.
+- Paste any changed "Copy" items into the release notes. You can generate these with [this tool](https://gist.github.com/rikukissa/9415b88016c0acfc0e0d4e00add45993).
+- Once finalized, **publish** the GitHub release.
+
+### 3. Publish NPM Release
+
+- In the core repository, ensure that the corresponding NPM package is published to reflect the new version.
+
+### 4. Version Control Management
+
+- In both the `core` and `countryconfig` repositories, **merge the release branch into `master`**.  
+  ⚠️ **Do not squash merge** — use a regular merge to preserve history.
+
+### 5. Documentation Management
+
+- Add the new release notes to the official documentation.
+- Create a placeholder for the next version's documentation.
+- Update OpenAPI specification URLs to point to the new release branch.
+- Publish the updated documentation.
+- Merge any open pull requests in the documentation repository, if appropriate.
+
+### 6. Environment Management
+
+- Merge the latest `countryconfig` updates into your country-specific repository.
+- **For minor releases**: Deploy the new version to **production**.
+- **For hotfix releases**: Deploy the new version to **staging**.
+
+### 7. Team Communication
+
+- Announce the newly published version to your team and stakeholders, ensuring they are informed and aligned.
+
+---
+
+By following this structured checklist, you ensure a smooth, transparent, and high-quality release process.
 
 ## Verification steps during release
 

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -47,7 +47,6 @@ This provides a fully functional environment for validating and reviewing the re
 
 ## Publishing the Release
 
-Once the release pull request has been generated via the [`Release - Start a new release`](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) workflow, a significant number of final tasks still remain to fully complete the release process.
 During this phase, it's common for issues to be discovered or additional pull requests to be merged into the release branch. Proceed carefully and ensure all necessary changes are included.
 
 {% hint style="warning" %}

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -13,7 +13,8 @@ To trigger this action, you are required to provide only the release version.
 {% hint style="warning" %}
 **⚠️ Caution** 
 - Ensure that the version number adheres to [semantic versioning](https://semver.org/) (e.g., `1.6.1`).
-- For a hotfix release, ensure that the branch corresponding to the previous release exists in both the `core` and `countryconfig` repositories.
+- For a minor release, the release branch will be created from develop branch.
+- For a **hotfix release**, make sure that the branch corresponding to the previous release exists in the `core`, `countryconfig`, and `farajaland` repositories. If it does not exist, create it first—otherwise, the workflow will fail. (e.g., If you are creating a hotfix release for version `1.6.2`, ensure that the `release/1.6.1` branch already exists.)
 {% endhint %}
 
 Once triggered, the action performs the following steps automatically:
@@ -22,15 +23,13 @@ Once triggered, the action performs the following steps automatically:
 - **Opens a pull request** to begin the release process.
 - **Updates `CHANGELOG.md`** heading with the specified version number.
 - **Modifies all `package.json` files** across the repository to reflect the new version.
+- **Creates a draft release** for core and countryconfig.
 
 ### Deployment to a Release Environment
 
-You can deploy a draft release to a dedicated release environment by running the [`Release - Provision Environment`](https://github.com/opencrvs/opencrvs-farajaland/blob/develop/.github/workflows/provision-release-environment.yml) workflow.
+You can deploy a draft release to a dedicated release environment by running the [`Release - Create Environment`](https://github.com/opencrvs/opencrvs-farajaland/actions/workflows/create-release-environment.yml) workflow.
 This workflow requires two input parameters:
-- **`Environment`**: A short identifier for the environment.  
-  *Tip:* If you are creating a release for version `v1.9.0`, enter `v19` as the input. This will result in a deployment like `v19.opencrvs.dev`.  
-  If you are releasing a patch version such as `v1.9.1`, you should still use `v19`.  
-  New environments are created only for minor releases.
+- **Select the branch** from which you want to run the workflow.
 - **`Core image tag`**: The Docker image tag for, core that you want to deploy.
 
 {% hint style="warning" %}

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -1,2 +1,14 @@
 # Releasing
 
+OpenCRVS follows a structured and coordinated release process to ensure stability and alignment between the core platform and country-specific configurations. Releases are versioned semantically (e.g., v1.4.0). Each release is accompanied by migration notes, upgrade instructions, and full changelogs to support system integrators and implementers.
+
+## Create the release pull request
+
+
+The first step in launching a new release is to create the release pull request—arguably the simplest part of the process. To do so, execute the GitHub Action titled `Release - Start a new release` available in the [opencrvs-core](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) repository.
+
+To trigger this action, you are required to provide only the release version.
+
+{% hint style="warning" %}
+Ensure that the version number adheres to [semantic versioning](https://semver.org/) (e.g., `1.6.1`).
+{% endhint %}

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -11,9 +11,8 @@ The first step in launching a new release is to create the release pull request.
 To trigger this action, you are required to provide only the release version.
 
 {% hint style="warning" %}
- **⚠️ Caution** 
-- Ensure that the version number adheres to [semantic versioning](https://semver.org/) (e.g., `1.6.1`).
-- Ensure there are no open pull requests that need to be included in the release—this applies to both the `countryconfig` and `core` repositories.
+**⚠️ Caution** 
+Ensure that the version number adheres to [semantic versioning](https://semver.org/) (e.g., `1.6.1`).
 {% endhint %}
 
 Once triggered, the action performs the following steps automatically:
@@ -40,7 +39,12 @@ Once triggered, the action will handle the rest of the setup automatically.
 ## Publishing the Release
 
 Once the release pull request has been generated via the [`Release - Start a new release`](https://github.com/opencrvs/opencrvs-core/actions/workflows/init-release.yml) workflow, a few final tasks remain to fully complete the release process.
+During this phase, it's common for issues to be discovered or additional pull requests to be merged into the release branch. Proceed carefully and ensure all necessary changes are included.
 
+{% hint style="warning" %}
+**⚠️ Caution**  
+Before proceeding to the next steps, make sure **there are no open pull requests** that need to be included in the release—this applies to both the `countryconfig` and `core` repositories.
+{% endhint %}
 
 ### 1. Tag the Release
 
@@ -51,8 +55,8 @@ git tag v1.7.0
 git push origin tag v1.7.0
 ```
 {% hint style="warning" %}
- **⚠️ Caution** 
-- Before creating a new Git tag, confirm that a tag with the same version number does not already exist in either the `countryconfig` or `core` repositories.
+**⚠️ Caution** 
+Before creating a new Git tag, confirm that a tag with the same version number does not already exist in either the `countryconfig` or `core` repositories.
 {% endhint %}
 
 ### 2. Publish & Verify Docker Images
@@ -67,8 +71,8 @@ git push origin tag v1.7.0
 - If there is a significant difference in size, report it to the maintainers for investigation.
 
 {% hint style="warning" %}
- **⚠️ Caution** 
-- Check Docker Hub (or the GitHub Container Registry for versions post `1.7.0` in core) to confirm that Docker images have been built and published using the correct release version name.
+**⚠️ Caution** 
+Check Docker Hub (or the GitHub Container Registry for versions post `1.7.0` in core) to confirm that Docker images have been built and published using the correct release version name.
 {% endhint %}
 
 ### 3. Finalize GitHub Release

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -25,11 +25,18 @@ Once triggered, the action performs the following steps automatically:
 
 ### Deployment to a Release Environment
 
-You can deploy a draft release to a dedicated release environment by running the `Release - Provision Environment` workflow.
+You can deploy a draft release to a dedicated release environment by running the [`Release - Provision Environment`](https://github.com/opencrvs/opencrvs-farajaland/blob/develop/.github/workflows/provision-release-environment.yml) workflow.
 This workflow requires two input parameters:
 - **`Environment`**: A short identifier for the environment.  
-  *Tip:* If you are creating a release for version `v1.9.0`, enter `v19` as the input. This will result in a deployment like `v19.opencrvs.dev`.
+  *Tip:* If you are creating a release for version `v1.9.0`, enter `v19` as the input. This will result in a deployment like `v19.opencrvs.dev`.  
+  If you are releasing a patch version such as `v1.9.1`, you should still use `v19`.  
+  New environments are created only for minor releases.
 - **`Core image tag`**: The Docker image tag for, core that you want to deploy.
+
+{% hint style="warning" %}
+⚠️ **Caution**  
+Make sure to run the workflow from the appropriate release branch.
+{% endhint %}
 
 Once triggered, this workflow will:
 - Create a server for the release environment

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -35,7 +35,7 @@ This workflow requires two input parameters:
 
 {% hint style="warning" %}
 ⚠️ **Caution**  
-Make sure to run the workflow from the release branch.
+Make sure to run the workflow from the corresponding release branch.
 {% endhint %}
 
 Once triggered, this workflow will:

--- a/v1.8.0/developers/workflows/releasing.md
+++ b/v1.8.0/developers/workflows/releasing.md
@@ -62,7 +62,7 @@ Before proceeding to the next steps, make sure **there are no open pull requests
 
 ### 1. Publish Docker Images to Container Registry
 
-You can publish all Docker images to our container registry by running the [`Publish Release`](https://github.com/opencrvs/opencrvs-core/blob/develop/.github/workflows/publish-release.yml) workflow in the `opencrvs-core` repository.
+You can publish all Docker images to our container registry by running the [`Publish Release`](https://github.com/opencrvs/opencrvs-core/blob/develop/.github/workflows/publish-release.yml) workflow in the `opencrvs-core` repository. For `opencrvs-countryconfig` you can publish all Docker images through [`Publish image to Dockerhub`](https://github.com/opencrvs/opencrvs-countryconfig/actions/workflows/publish-to-dockerhub.yml) workflow. 
 
 > 💡 This step ensures that all release-related images are built and made available in the appropriate container registry.
 


### PR DESCRIPTION
In 1.8.0 documentation, let's create a new "Releasing" page 

Developers
  - Workflows
    -  **Releasing** 

That describes the release process from [this diagram](https://www.figma.com/board/6pWbTiYQREtCVRfvlhKSvX/Release-process?node-id=0-1&p=f&t=aIP7tFyKazuohiYS-0) as written steps after the automations (top left corner) are finished.

It should a "guide" type of a page that leads the reader (IET team) through the necessary steps of first creating a release PR, deploying it to a release environment and then wrapping up the release

Tasks
- [x] Document how to create the release pull request
- [x] Document how the deployment to a release environment works
- [x] Document the next steps until the release has been wrapped
- [x] Document the "verification steps" (pink labels in the diagram)