### PR TITLE
fix: Broken links and quick start update

### DIFF
--- a/v2.0.0-latest/technical/guides/installation/advanced-topics/add-custom-github-secrets-to-kubernetes.md
+++ b/v2.0.0-latest/technical/guides/installation/advanced-topics/add-custom-github-secrets-to-kubernetes.md
@@ -8,7 +8,7 @@ GitHub secrets are grouped per environment and at repository level, secret defin
 
 OpenCRVS Helm chart stores database connection properties and other sensitive data like SMTP configuration, backup credentials as Kubernetes secrets.
 
-Check following link for default secrets specification at [Authentication configuration](https://github.com/opencrvs/opencrvs-helm-charts/tree/develop/charts/opencrvs-services/README.md#authentication-configuration) (helm chart README.md)
+Check following link for default secrets specification at [Authentication configuration](https://github.com/opencrvs/opencrvs-core/tree/develop/charts/opencrvs-services/README.md#authentication-configuration) (helm chart README.md)
 
 ## SMTP secret mapping example
 
@@ -22,7 +22,7 @@ Country config image requires SMTP server configuration for emails. Following en
 * SMTP\_USERNAME
 * ALERT\_EMAIL
 
-Full description is at [4.3.1.1 Environment secrets and variables explained](/broken/pages/m3JwlnOGzTYIpoXdEwyu)
+Full description is at [Environment secrets and variables explained](../deploy-set-up-a-server-hosted-environment/create-a-github-environment/environment-secrets-and-variables-explained.md)
 
 Steps to add GitHub secrets to Kubernetes
 
@@ -38,7 +38,7 @@ Steps to add GitHub secrets to Kubernetes
       # data: Mapping between particular GitHub secret 
       # and Secret key inside kubernetes secret
       # Format is &#x3C;GH Secret>:[Kubernetes secret key],
-      # if Kubernetes secret key then it's key will be the same as GitHub secret
+      # If the Kubernetes Secret key is omitted, the GitHub secret name will be used as the key.
       data:
         - SENDER_EMAIL_ADDRESS
         - SMTP_HOST
@@ -52,7 +52,7 @@ Steps to add GitHub secrets to Kubernetes
     1. For mapping secrets in dependencies: [.github/TEMPLATES/secret-mapping-opencrvs-deps.yml](https://github.com/opencrvs/infrastructure/blob/develop/.github/TEMPLATES/secret-mapping-opencrvs-deps.yml)
     2. For mapping secrets in OpenCRVS: [.github/TEMPLATES/secret-mapping-opencrvs.yml](https://github.com/opencrvs/infrastructure/blob/develop/.github/TEMPLATES/secret-mapping-opencrvs.yml)
 3.  Map values from secret to particular container in helm chart values:\
-    Check documentation for more information: [Mapping secrets](https://github.com/opencrvs/opencrvs-helm-charts/blob/develop/charts/opencrvs-services/README.md#mapping-secrets) (Helm chart README.md)
+    Check documentation for more information: [Mapping secrets](https://github.com/opencrvs/opencrvs-core/blob/develop/charts/opencrvs-services/README.md#mapping-secrets) (Helm chart README.md)
 
     <pre class="language-yaml" data-title="Example of mapping secret keys from &#x22;smtp-config&#x22; secret to countryconfig service"><code class="lang-yaml">countryconfig:
       secrets:

--- a/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/create-a-github-environment/README.md
+++ b/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/create-a-github-environment/README.md
@@ -308,7 +308,7 @@ Review modified files:
 ### Final notice
 
 {% hint style="danger" %}
-The later [provision](/broken/pages/VxyJDdy72Mi1awNbEQTu) script will disable password SSH access for all users on the server and create new users from the `infrastructure/server-setup/inventory/<environment name>.yml` file. After provisioning, SSH will only be possible using public/private key pairs.
+The later [provision](../provisioning-servers/README.md) script will disable password SSH access for all users on the server and create new users from the `infrastructure/server-setup/inventory/<environment name>.yml` file. After provisioning, SSH will only be possible using public/private key pairs.
 {% endhint %}
 
 {% hint style="success" %}

--- a/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/deploy/README.md
+++ b/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/deploy/README.md
@@ -10,9 +10,9 @@ This deployment guide covers deployment processes for the following components:
 
 All OpenCRVS images except the country configuration template are hosted in the [GitHub container registry](https://github.com/orgs/opencrvs/packages?ecosystem=container).
 
-### Publishing your countryconfig container to Dockerhub
+### Publishing your countryconfig image to Dockerhub
 
-The default country configuration container is hosted on our DockerHub.
+The default country configuration image is hosted on our DockerHub.
 
 You will need to register your own DockerHub account and create a private repository.
 
@@ -25,5 +25,5 @@ If you look at the logs for each build, you can see the image tag associated wit
 Once you are certain that your image is successfully being built and hosted on DockerHub, you can continue.
 
 {% hint style="warning" %}
-We strongly recommend that you have enabled an [approval](/broken/pages/WMQcGxLMRv5zwOleQjRV) process for all deployment scripts to **production** and **staging** environments.&#x20;
+We strongly recommend that you have enabled an [approval](../create-a-github-environment/approval-process-for-production-environments.md) process for all deployment scripts to **production** and **staging** environments.&#x20;
 {% endhint %}

--- a/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/deploy/login-to-an-opencrvs-server.md
+++ b/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/deploy/login-to-an-opencrvs-server.md
@@ -48,7 +48,7 @@ Seeding users
 Done in 9.15s.
 ```
 
-If for some reason data seed job was not executed or failed at installation time, please check [Seeding a server environment](/broken/pages/3VuIbK6io13npPWymc1x) to get more information how to re-run job.
+If for some reason data seed job was not executed or failed at installation time, please check [Seeding a server environment](../../opencrvs-maintenance-tasks/seeding-a-server-environment.md) to get more information how to re-run job.
 
 ### Debugging SMTP
 
@@ -62,4 +62,4 @@ As the SMTP API was configured in the countryconfig service, you can filter the 
 kubernetes.container.name : "countryconfig"
 ```
 
-As you browse the logs you are looking for 500 errors and you can respond to any SMTP service error messages that you see appropriately. Perhaps you need to change the Github Action secrets. [Running a deployment ](/broken/pages/XcATcz2Mx4xP3j8TiC6W)of OpenCRVS will refresh all microservices and so this is required when secrets are updated.
+As you browse the logs you are looking for 500 errors and you can respond to any SMTP service error messages that you see appropriately. Perhaps you need to change the Github Action secrets. [Running a deployment ](./running-a-opencrvs-deployment.md)of OpenCRVS will refresh all microservices and so this is required when secrets are updated.

--- a/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/deploy/running-a-dependencies-deployment.md
+++ b/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/deploy/running-a-dependencies-deployment.md
@@ -9,7 +9,7 @@ A deployment to a **staging** environment is not permitted unless a **production
 This section explains how to deploy OpenCRVS dependencies grouped in 2 helm charts:
 
 * **Ingress controller:** [Traefik](https://doc.traefik.io/traefik/) helm chart
-* **Datastores** (via the [OpenCRVS dependencies Helm chart](https://github.com/opencrvs/infrastructure/tree/develop/charts/opencrvs-services)):
+* **Datastores** (via the [OpenCRVS dependencies Helm chart](https://github.com/opencrvs/opencrvs-core/tree/develop/charts/opencrvs-services)):
   * MongoDB
   * PostgreSQL
   * Elasticsearch
@@ -39,7 +39,7 @@ A default configuration, created by the `yarn environments:init` script, is suff
 
 1. Navigate to GitHub Actions within `infrastructure` repository
 2. Select "Deploy Dependencies" action
-3. Select "Target environment" from dropdown menu, all environments created at [Broken link](/broken/pages/Ar8Os7JHqW6KnBmoDslD "mention") step should be listed here.
+3. Select "Target environment" from dropdown menu, all environments created at [Create a GitHub Environment](../create-a-github-environment/README.md) step should be listed here.
 4. Click "Run workflow" button
 
 ### Verification steps
@@ -47,7 +47,7 @@ A default configuration, created by the `yarn environments:init` script, is suff
 * Verify workflow was completed successfully
 * Verify resources are up and running after deployment:
   * `kubectl get namespaces` : You should see 2 new namespaces created (`traefik`, `opencrvs-deps-<env>`).\
-    NOTE: Check how to run `kubectl` at [Kubernetes cluster access](/broken/pages/Oo19SaQmBF4hLOVclF06).
+    NOTE: Check how to run `kubectl` at [Kubernetes cluster access](../../advanced-topics/kubernetes-cluster-access.md).
   * `kubectl get pods -n traefik`: Make sure traefik pod is up and running
   *   `kubectl get pods -n opencrvs-deps-<environment>` : make sure datastores are up and running.\
       Example output: If monitoring is enabled, you will also see filebeat, metricbeat, kibana pods.

--- a/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/deploy/running-a-opencrvs-deployment.md
+++ b/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/deploy/running-a-opencrvs-deployment.md
@@ -31,5 +31,5 @@ You can deploy to your server using the automated **"Deploy OpenCRVS"** Github A
     ```
     kubectl get jobs
     ```
-* Access opencrvs in browser: `https://<your domain>` , see [Login to an OpenCRVS server](/broken/pages/ztqRF48zpvzwtCgJDpSY)
+* Access opencrvs in browser: `https://<your domain>` , see [Login to an OpenCRVS server](./login-to-an-opencrvs-server.md)
 

--- a/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/migration-from-docker-swarm-guide.md
+++ b/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/migration-from-docker-swarm-guide.md
@@ -15,14 +15,13 @@ This tutorial guides you through all steps required to transform your v1.9 Docke
 
 #### 1. Infrastructure Repository
 
-OpenCRVS v2.0+ uses a dedicated repository for continuous delivery configuration:
+OpenCRVS v2.0+ uses a dedicated **repository** for continuous delivery configuration: [https://github.com/opencrvs/infrastructure](https://github.com/opencrvs/infrastructure)
 
-**Repository:** [https://github.com/opencrvs/infrastructure](https://github.com/opencrvs/infrastructure)
+**Repository:** 
 
 **Required Action:**
 
 * Fork this repository to your organization or personal GitHub account before starting migration
-* Detailed forking steps are provided in [Broken link](/broken/pages/03CDotfjzMxY2UDbp5W4#id-4.-fork-or-clone-repositories "mention")
 * Ensure that your user has admin rights over the repository
 
 #### 2. SSH Access Configuration
@@ -100,7 +99,7 @@ All OpenCRVS services are deployed as helm charts during migration.
 
 All customizations must be **re-implemented using a custom Helm chart**.
 
-An example custom helm chart is published as part of the infrastructure repository, see [https://github.com/opencrvs/infrastructure/tree/develop/charts/opencrvs-mosip](https://github.com/opencrvs/infrastructure/tree/develop/charts/opencrvs-mosip)
+An example custom helm chart is published at OpenCRVS Core repository, see [https://github.com/opencrvs/opencrvs-core/tree/develop/charts/opencrvs-mosip](https://github.com/opencrvs/opencrvs-core/tree/develop/charts/opencrvs-mosip)
 
 You may also choose to use [Bitnami Common Library Chart](https://github.com/bitnami/charts/tree/main/bitnami/common) for more advanced use cases.
 
@@ -166,7 +165,7 @@ Make sure all preparations steps completed
     <figure><img src="../../../../.gitbook/assets/image (5).png" alt=""><figcaption></figcaption></figure>
 5. Review changes within PR:
    1. If your docker-compose file had any customisations like environment variables, please add them to `environments/<env name>/opencrvs-services/values.yaml`&#x20;
-   2. By default traefik is configured to use static ssl certificates, adjust values if needed, check documentation at [Broken link](/broken/pages/0tRt9sXOzixEtLZQot7O "mention")
+   2. By default traefik is configured to use static ssl certificates, adjust values if needed, check documentation at [TLS/SSL Configuration for traefik](../advanced-topics/tls-ssl-configuration-for-traefik/README.md)
 6.  Merge Pull request to main (develop) branch. If multiple environments were migrated at the same time, you will need to resolve pull request conflicts manually, usually effected section is `environment` input selector:
 
     <figure><img src="../../../../.gitbook/assets/image (6).png" alt=""><figcaption></figcaption></figure>
@@ -175,10 +174,10 @@ Make sure all preparations steps completed
 
 **Kubernetes environment provision and deploy**
 
-1. Provision Kubernetes environment on top of Docker Swarm environment: Run Provision workflow from Infrastructure repository, see for more information [Broken link](/broken/pages/VxyJDdy72Mi1awNbEQTu "mention")
+1. Provision Kubernetes environment on top of Docker Swarm environment: Run Provision workflow from Infrastructure repository, see for more information [Provisioning servers](./provisioning-servers/README.md)
 2. Reboot your target server
-3. Deploy dependencies, see for more information [Broken link](/broken/pages/ludL25iSv5QmOBkwXe2D "mention")
-4. Deploy OpenCRVS: see for more information [Broken link](/broken/pages/XcATcz2Mx4xP3j8TiC6W "mention")
+3. Deploy dependencies, see for more information [Running Dependencies deployment](./deploy/running-a-dependencies-deployment.md)
+4. Deploy OpenCRVS: see for more information [Running an OpenCRVS deployment](./deploy/running-a-opencrvs-deployment.md)
    1. Use same OpenCRVS Core image tag as docker swarm
    2. Use same Country config image tag as docker swarm
    3.  Make sure "Enable data seeding during deployment" is unchecked
@@ -265,8 +264,6 @@ This section outlines the fundamental differences in backup and restore implemen
 * Each job runs as a **Kubernetes pod** with database client tools
 
 The fundamental shift is from **filesystem-based operations** to **network-based database operations**. While this introduces network overhead, it provides the flexibility and portability required for modern cloud-native deployments, including support for managed database services and multi-environment consistency.
-
-Check [Broken link](/broken/pages/ksyXmFt3UUOXzLvqFFAN "mention") for more information and configuration details.
 
 ## GitHub Fine-grained token
 

--- a/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/preparation-steps/setup-infrastructure.md
+++ b/v2.0.0-latest/technical/guides/installation/deploy-set-up-a-server-hosted-environment/preparation-steps/setup-infrastructure.md
@@ -202,7 +202,7 @@ disk_encryption_key_path: /root/disk-encryption-key.txt
 ```
 
 {% hint style="success" %}
-All the secrets are explained in more detail in the section [4.3.1.1 Environment secrets and variables explained.](/broken/pages/m3JwlnOGzTYIpoXdEwyu)
+All the secrets are explained in more detail in the section [Environment secrets and variables explained.](../create-a-github-environment/environment-secrets-and-variables-explained.md)
 {% endhint %}
 
 ### Server clusters by project

--- a/v2.0.0-latest/technical/guides/installation/opencrvs-maintenance-tasks/backup-and-restore/README.md
+++ b/v2.0.0-latest/technical/guides/installation/opencrvs-maintenance-tasks/backup-and-restore/README.md
@@ -5,7 +5,7 @@
 ### General information
 
 {% hint style="info" %}
-Backup and restore is automatically configured while environment creation by `yarn environment:init` script, check [Broken link](/broken/pages/Ar8Os7JHqW6KnBmoDslD "mention"). This guide dives into details:
+Backup and restore is automatically configured while environment creation by `yarn environment:init` script, check [Create a Github environment](../../deploy-set-up-a-server-hosted-environment/create-a-github-environment/README.md). This guide dives into details:
 
 * How to configure backup and restore without GitHub integration?
 * How to perform manual backup?

--- a/v2.0.0-latest/technical/guides/installation/opencrvs-maintenance-tasks/backup-and-restore/automated-backup-configuration.md
+++ b/v2.0.0-latest/technical/guides/installation/opencrvs-maintenance-tasks/backup-and-restore/automated-backup-configuration.md
@@ -16,9 +16,9 @@ backup:
   backup_server_dir: /home/backup/<environment>
 ```
 
-Push your changes to GitHub and Re-[Deploy Dependencies](/broken/pages/ludL25iSv5QmOBkwXe2D)
+Push your changes to GitHub and Re-[Deploy Dependencies](../../deploy-set-up-a-server-hosted-environment/deploy/running-a-dependencies-deployment.md)
 
-If backup server was provisioned as part of any other environments or is a third-party server, then please follow guide from helm chart, see [Backup configuration](https://github.com/opencrvs/infrastructure/blob/develop/charts/dependencies/README.md#backup-configuration).
+If backup server was provisioned as part of any other environments or is a third-party server, then please follow guide from helm chart, see [Backup configuration](https://github.com/opencrvs/opencrvs-core/blob/develop/charts/dependencies/README.md#backup-configuration).
 
 ### Verify backup configuration
 
@@ -81,7 +81,7 @@ Verify backup files are present on backup server
     Example output:
 
     ```
-    backup@tmp-backup:~$ ls -l /home/backup/production/2025-11-12
+    backup@backup-01:~$ ls -l /home/backup/production/2025-11-12
     total 25972
     -rw-r--r-- 1 backup backup    74704 Nov 12 01:00 influxdb_backup_2025-11-12.tar.gz.enc
     -rw-r--r-- 1 backup backup 26506864 Nov 12 01:00 minio_backup_2025-11-12.tar.gz.enc

--- a/v2.0.0-latest/technical/guides/installation/opencrvs-maintenance-tasks/backup-and-restore/manual-restore-disaster-recovery.md
+++ b/v2.0.0-latest/technical/guides/installation/opencrvs-maintenance-tasks/backup-and-restore/manual-restore-disaster-recovery.md
@@ -28,7 +28,7 @@ Usually reasons for manual restore:
 ### Manual restore when Automated restore is configured
 
 {% hint style="info" %}
-Its recommended to configure connection to cluster as described at [Add new cluster to your default kubeconfig](/broken/pages/Oo19SaQmBF4hLOVclF06#option-3-add-new-cluster-to-your-default-kubeconfig) before running this task.
+Its recommended to configure connection to cluster as described at [Add new cluster to your default kubeconfig](../../advanced-topics/kubernetes-cluster-access.md#option-3-add-new-cluster-to-your-default-kubeconfig) before running this task.
 {% endhint %}
 
 1. From your laptop SSH (login) to backup server and make sure latest backup exists, if for some reasons backup is not there, please follow **Manual restore** scenario.
@@ -78,7 +78,7 @@ Its recommended to configure connection to cluster as described at [Add new clus
 ### Manual restore / Disaster recovery
 
 {% hint style="info" %}
-Its recommended to configure connection to cluster as described at [Add new cluster to your default kubeconfig](/broken/pages/Oo19SaQmBF4hLOVclF06#option-3-add-new-cluster-to-your-default-kubeconfig) before running this task.
+Its recommended to configure connection to cluster as described at [Add new cluster to your default kubeconfig](../../advanced-topics/kubernetes-cluster-access.md#option-3-add-new-cluster-to-your-default-kubeconfig) before running this task.
 {% endhint %}
 
 * From your laptop SSH (login) to backup server

--- a/v2.0.0-latest/technical/guides/installation/opencrvs-maintenance-tasks/backup-and-restore/restoring-a-backup.md
+++ b/v2.0.0-latest/technical/guides/installation/opencrvs-maintenance-tasks/backup-and-restore/restoring-a-backup.md
@@ -29,7 +29,7 @@ It also requires the backup encryption key, which is stored in the same namespac
 The steps for copying these secrets from the production cluster, adjusting them as needed, and creating them in the staging cluster are described below.
 
 {% hint style="info" %}
-Its recommended to configure connection to cluster as described at [Add new cluster to your default kubeconfig](/broken/pages/Oo19SaQmBF4hLOVclF06#option-3-add-new-cluster-to-your-default-kubeconfig) before running this task.
+Its recommended to configure connection to cluster as described at [Add new cluster to your default kubeconfig](../../advanced-topics/kubernetes-cluster-access.md#option-3-add-new-cluster-to-your-default-kubeconfig) before running this task.
 {% endhint %}
 
 1.  Connect to production cluster with `kubectl` :
@@ -125,7 +125,7 @@ restore:
   backup_encryption_secret: restore-encryption-secret
 ```
 
-Push your changes to github and Re-[Deploy Dependencies](/broken/pages/ludL25iSv5QmOBkwXe2D)
+Push your changes to github and Re-[Deploy Dependencies](../../deploy-set-up-a-server-hosted-environment/deploy/running-a-dependencies-deployment.md)
 
 #### Enable reindex in OpenCRVS helm chart values
 
@@ -141,7 +141,7 @@ elasticsearch:
     schedule "0 2 * * *"
 ```
 
-Push your changes to github and Re-[Deploy OpenCRVS](/broken/pages/XcATcz2Mx4xP3j8TiC6W)
+Push your changes to github and Re-[Deploy OpenCRVS](../../deploy-set-up-a-server-hosted-environment/deploy/running-a-opencrvs-deployment.md)
 
 ## Verify restore configuration
 

--- a/v2.0.0-latest/technical/guides/installation/opencrvs-maintenance-tasks/seeding-a-server-environment.md
+++ b/v2.0.0-latest/technical/guides/installation/opencrvs-maintenance-tasks/seeding-a-server-environment.md
@@ -11,11 +11,11 @@ OpenCRVS helm chart seeds data at installation time and can be performed only on
 There are few scenarios when you need to seed data again:
 
 * **Changes to Country config codebase:** In that scenario please complete following steps:
-  * [Run OpenCRVS deployment](/broken/pages/XcATcz2Mx4xP3j8TiC6W): Codebase will be deployed on target environment
-  * [Reset a server environment](/broken/pages/OGG4O5Cr5aOXP3cNR5gC): Cleanup database for update with new schema and data
+  * [Run OpenCRVS deployment](../deploy-set-up-a-server-hosted-environment/deploy/running-a-opencrvs-deployment.md): Codebase will be deployed on target environment
+  * [Reset a server environment](./resetting-a-server-environment.md): Cleanup database for update with new schema and data
   * [Run "Seed data" workflow](seeding-a-server-environment.md#run-seed-data-workflow): Populate new schema and data
 * **Reset environment to initial state:**
-  * [Reset a server environment](/broken/pages/OGG4O5Cr5aOXP3cNR5gC)
+  * [Reset a server environment](./resetting-a-server-environment.md)
   * [Run "Seed data" workflow](seeding-a-server-environment.md#run-seed-data-workflow)
 * **Seed was not executed at installation time due to any kind of errors:** In this case run data seed manually, see [Run "Seed data" workflow](seeding-a-server-environment.md#run-seed-data-workflow)
 
@@ -28,4 +28,4 @@ If for some reason data seed was not executed at OpenCRVS installation time, ple
 3. Select "Target environment" from dropdown menu, all environments created at [4.3.1-create-a-github-environment](../../../../../../v2.0.0/setup/3.-installation/3.3-set-up-a-server-hosted-environment/4.3.1-create-a-github-environment "mention") step should be listed here.
 4. Click "Run workflow" button
 
-If an error occurs, the environment must be reset before it can be seeded again. Resetting an environment is explained [here](/broken/pages/OGG4O5Cr5aOXP3cNR5gC).
+If an error occurs, the environment must be reset before it can be seeded again. Resetting an environment is explained [here](./resetting-a-server-environment.md).

--- a/v2.0.0-latest/technical/guides/installation/quick-start.md
+++ b/v2.0.0-latest/technical/guides/installation/quick-start.md
@@ -8,25 +8,30 @@ npm create @opencrvs/countryconfig <project-name>
 
 This command creates a country configuration package with a minimal example configuration.
 
+### Run local development environment
 
+Make sure all prerequisites are installed, see [opencrvs-coutnryconfig](https://github.com/opencrvs/opencrvs-countryconfig/#prerequisites)
 
-### Fork (or clone) repositories
+Navigate to `<project-name>-countryconfig`
 
-Create your own forks from the following repositories:Country configuration.&#x20;
+Start development environemnt:
+```
+tilt up
+```
 
-* [https://github.com/opencrvs/infrastructure](https://github.com/opencrvs/infrastructure): Repository is used to store Infrastructure and CI/CD configuration (ansible inventory files and helm release values).
+Open the Tilt UI:
+```
+http://localhost:10350
+```
+Wait until the main resources are running.
 
-**Steps to fork a repository:**
+Then run the data seed task from the Tilt UI:
+1. Open http://localhost:10350
+2. Find the `2.Data-tasks` section
+3. Run the `seed-data` or `clean-&-seed` resource
+4. Wait until the job completes
 
-1. Go to [https://github.com/opencrvs/infrastructure](https://github.com/opencrvs/infrastructure)&#x20;
-2. In the top right corner press "Fork" button
-3. Provide "Owner" and "Repository name" values
-4. Press "Create fork" button.
+Open OpenCRVS: http://opencrvs.localhost
 
-**For CI/CD:**
+Thats it! 🎉
 
-Create a [Github Personal Access Token ](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)with the required permissions in order for the script to programmatically create Github environments on your forked repository. Usually, the only required scope for the token is "repo".
-
-{% hint style="warning" %}
-Set the token expiration time as needed. Keep in mind that the token secret must be updated regularly for deployment actions to continue working after it expires.
-{% endhint %}


### PR DESCRIPTION
Goal of this PR is to improve v2.0 documentation:
- fixed multiple broken links
- updated Quick start guide

Following pages are not available in v2.0 yet:
- [4.3.5.2 Building, pushing & releasing your countryconfig code](https://documentation.opencrvs.org/setup/3.-installation/3.3-set-up-a-server-hosted-environment/4.3.5-provisioning-servers/4.3.5.2-building-pushing-and-releasing-your-countryconfig-code)
- [4.1.1 Install the required dependencies](https://documentation.opencrvs.org/setup/3.-installation/3.1-set-up-a-development-environment/3.1.1-install-the-required-dependencies)